### PR TITLE
use portable shebang

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 THEMEDIRECTORY=$(cd `dirname $0` && cd .. && pwd)
 FIREFOXFOLDER=~/.mozilla/firefox/


### PR DESCRIPTION
Using a more portable shebang allows the install script to work on systems without `/bin/bash` (such as NixOS).