### PR TITLE
113 fix

### DIFF
--- a/theme/parts/buttons.css
+++ b/theme/parts/buttons.css
@@ -60,7 +60,7 @@ button.close,
 }
 
 .subviewbutton-iconic {
-	-moz-box-pack: center !important;
+	justify-content: center !important;
 }
 
 /* Buttons with margins */

--- a/theme/parts/buttons.css
+++ b/theme/parts/buttons.css
@@ -60,7 +60,7 @@ button.close,
 }
 
 .subviewbutton-iconic {
-	justify-content: center !important;
+	justify-items: center !important;
 }
 
 /* Buttons with margins */

--- a/theme/parts/popups-contents.css
+++ b/theme/parts/popups-contents.css
@@ -28,7 +28,7 @@
 
 /* Main menu */
 #appMenu-popup .panel-banner-item:after {
-	-moz-box-ordinal-group: 0;
+	order: -1;
 	margin: 0 8px 0 0 !important;
 }
 #appMenu-popup .toolbaritem-combined-buttons {

--- a/theme/parts/popups.css
+++ b/theme/parts/popups.css
@@ -192,8 +192,8 @@ menupopup menu:not([disabled="true"]):is(:hover, [_moz-menuactive]),
 .subviewbutton-back {
 	opacity: 1 !important;
 	width: 100%;
-	-moz-box-align: center !important;
-	-moz-box-pack: start !important;
+	align-content: center !important;
+	justify-content: flex-start !important;
 	padding: 10px !important;
 }
 .subviewbutton-back + h1 {

--- a/theme/parts/popups.css
+++ b/theme/parts/popups.css
@@ -192,7 +192,7 @@ menupopup menu:not([disabled="true"]):is(:hover, [_moz-menuactive]),
 .subviewbutton-back {
 	opacity: 1 !important;
 	width: 100%;
-	align-content: center !important;
+	align-items: center !important;
 	justify-content: flex-start !important;
 	padding: 10px !important;
 }

--- a/theme/parts/sidebar.css
+++ b/theme/parts/sidebar.css
@@ -33,3 +33,6 @@
 	padding: 6px !important;
 }
 
+#sidebar-switcher-target {
+  flex: unset !important;
+}

--- a/theme/parts/toolbox.css
+++ b/theme/parts/toolbox.css
@@ -51,19 +51,19 @@ findbar:-moz-window-inactive label,
 
 /* Reorder toolbars */
 #navigator-toolbox #nav-bar, findbar {
-	-moz-box-ordinal-group: 0;
+	order: -1;
 }
 #navigator-toolbox #PersonalToolbar {
-	-moz-box-ordinal-group: 1;
+	order: 0;
 }
 #navigator-toolbox #titlebar {
-	-moz-box-ordinal-group: 2;
+	order: 1;
 }
 #navigator-toolbox toolbar {
-	-moz-box-ordinal-group: 10;
+	order: 10;
 }
 #navigator-toolbox #TabsToolbar {
-	-moz-box-ordinal-group: 100;
+	order: 100;
 }
 
 /* Overrides: Don't shift other toolbars on tab drag and drop */


### PR DESCRIPTION
The primary fix is changing `moz-box-ordinal-group` to `order` in toolbox.css. This corrects the overlapping caused by the change from moz-box to flex as the default display model in version 113.

The `moz-box-pack` and `moz-box-align` were changed to the flexbox `*-content` equivalents, although I couldn't find their actual usage when inspecting the browser. They may need to be adjusted to `*-items` if necessary.

There's also a minor fix for the sidebar switcher collapsing due to `flex: 1`, so it now properly displays the full title of the current sidebar option that is selected.